### PR TITLE
Switch gtest submodule to github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/gtest"]
 	path = third_party/gtest
-	url = https://git.chromium.org/git/external/googletest.git
+	url = https://github.com/svn2github/googletest.git


### PR DESCRIPTION
git.chromium.org is maximally flakey.
