### PR TITLE
Make most public interfaces pure virtual

### DIFF
--- a/example/echo-server.cc
+++ b/example/echo-server.cc
@@ -52,7 +52,7 @@ private:
 };
 
 struct Connection {
-    Connection(wte::EventBase *base, int fd)
+    Connection(std::shared_ptr<wte::EventBase> base, int fd)
         : stream(wte::wrapFd(base, fd)),
           write_cb(this),
           read_cb(this, &write_cb) { }
@@ -84,7 +84,7 @@ void EchoReadCallback::error(std::runtime_error const& e) {
     delete conn_;
 }
 
-static void acceptCb(wte::EventBase *base, int fd) {
+static void acceptCb(std::shared_ptr<wte::EventBase> base, int fd) {
     Connection *conn = new Connection(base, fd);
     conn->stream->startRead(&conn->read_cb);
 }
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
     WSAStartup(version, &data);
 #endif
 
-    auto* base = wte::mkEventBase();
+    auto base = wte::mkEventBase();
     auto* listener = wte::mkConnectionListener(base,
         std::bind(acceptCb, base, std::placeholders::_1), errorCb);
 
@@ -113,7 +113,6 @@ int main(int argc, char **argv) {
     base->loop(wte::EventBase::LoopMode::FOREVER);
 
     delete listener;
-    delete base;
 
     return 0;
 }

--- a/example/echo-server.cc
+++ b/example/echo-server.cc
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
 #endif
 
     auto base = wte::mkEventBase();
-    auto* listener = wte::mkConnectionListener(base,
+    auto listener = wte::mkConnectionListener(base,
         std::bind(acceptCb, base, std::placeholders::_1), errorCb);
 
     listener->bind(0);
@@ -111,8 +111,6 @@ int main(int argc, char **argv) {
 
     printf("Ready to talk back on %d\n", listener->port());
     base->loop(wte::EventBase::LoopMode::FOREVER);
-
-    delete listener;
 
     return 0;
 }

--- a/src/blocking_stream.cc
+++ b/src/blocking_stream.cc
@@ -63,7 +63,7 @@ public:
      */
     int64_t read(char *buf, size_t size) override;
 private:
-    EventBase *base_;
+    std::shared_ptr<EventBase> base_;
     std::unique_ptr<Stream, Stream::Deleter> stream_;
     bool close_;
 };
@@ -76,7 +76,7 @@ BlockingStreamImpl::~BlockingStreamImpl() {
         // TODO: close
     }
     stream_.reset(nullptr);
-    delete base_;
+    base_.reset();
 }
 
 namespace {

--- a/src/blocking_stream.cc
+++ b/src/blocking_stream.cc
@@ -30,10 +30,48 @@
 
 namespace wte {
 
-BlockingStream::BlockingStream(int fd, bool auto_close)
+class BlockingStreamImpl final : public BlockingStream {
+public:
+    /**
+     * Construct a blocking stream wrapper around an existing descriptor.
+     *
+     * @param fd the file descriptor
+     * @param auto_close whether to close the descriptor on destruction
+     */
+    BlockingStreamImpl(int fd, bool auto_close);
+
+    ~BlockingStreamImpl();
+
+    /**
+     * Writes the buffer into the stream, blocking if necessary.
+     *
+     * @param buf the buffer
+     * @param size the buffer length
+     * @throws on error
+     */
+    void write(const char *buf, size_t size) override;
+
+    /**
+     * Read up to the requested size, blocking if necessary.
+     *
+     * May return short reads on EOF.
+     *
+     * @param buf the buffer
+     * @param size the buffer length
+     * @return the number of bytes read
+     * @throws on error
+     */
+    int64_t read(char *buf, size_t size) override;
+private:
+    EventBase *base_;
+    std::unique_ptr<Stream, Stream::Deleter> stream_;
+    bool close_;
+};
+
+BlockingStreamImpl::BlockingStreamImpl(int fd, bool auto_close)
     : base_(mkEventBase()), stream_(wrapFd(base_, fd)), close_(auto_close) { }
 
-BlockingStream::~BlockingStream() {
+BlockingStreamImpl::~BlockingStreamImpl() {
     if (close_) {
         // TODO: close
     }
@@ -89,7 +127,7 @@ public:
 
 } // unnamed namespace
 
-void BlockingStream::write(const char *buf, size_t size) {
+void BlockingStreamImpl::write(const char *buf, size_t size) {
     BlockingWriteCallback cb;
     stream_->write(buf, size, &cb);
     base_->loop(EventBase::LoopMode::UNTIL_EMPTY);
@@ -99,7 +137,7 @@ void BlockingStream::write(const char *buf, size_t size) {
     assert(cb.complete_);
 }
 
-int64_t BlockingStream::read(char *buf, size_t size) {
+int64_t BlockingStreamImpl::read(char *buf, size_t size) {
     BlockingReadCallback cb(buf, size);
     stream_->startRead(&cb);
 
@@ -112,6 +150,16 @@ int64_t BlockingStream::read(char *buf, size_t size) {
     }
 
     return cb.nread_;
+}
+
+void BlockingStream::Deleter::operator()(BlockingStream *bs) {
+    delete bs;
+}
+
+std::unique_ptr<BlockingStream, BlockingStream::Deleter>
+BlockingStream::create(int fd, bool auto_close) {
+    return std::unique_ptr<BlockingStream, Deleter>(
+        new BlockingStreamImpl(fd, auto_close), Deleter());
 }
 
 } // wte namespace

--- a/src/buffer-internal.h
+++ b/src/buffer-internal.h
@@ -29,32 +29,34 @@
 
 namespace wte {
 
-class BufferImpl {
+class BufferImpl final : public Buffer {
 public:
     BufferImpl();
     ~BufferImpl();
 
-    void append(const char *buf, size_t size);
-    void append(BufferImpl *o);
-    void prepend(const char *buf, size_t size);
-    void prepend(BufferImpl *o);
+    void append(const char *buf, size_t size) override;
+    void append(std::string const& buf) override;
+    void append(Buffer *o) override;
+    void prepend(const char *buf, size_t size) override;
+    void prepend(std::string const& buf) override;
+    void prepend(Buffer *o) override;
 
     // Copy data out, consuming in the process
-    void read(char *buf, size_t size, size_t *nread);
+    void read(char *buf, size_t size, size_t *nread) override;
 
     // Copy data out, without consuming
-    void peek(char *buf, size_t size, size_t *nread) const;
+    void peek(char *buf, size_t size, size_t *nread) const override;
 
     // Peek at data without consuming, using extents
-    void peek(size_t size, std::vector<Extent> *extents) const;
+    void peek(size_t size, std::vector<Extent> *extents) const override;
 
     // Drain data
-    void drain(size_t count);
+    void drain(size_t count) override;
 
-    bool empty() const;
-    size_t size() const { return size_; }
-    void reserve(size_t capacity);
-    void reserve(size_t capacity, std::vector<Extent> *extents);
+    bool empty() const override;
+    size_t size() const override { return size_; }
+    void reserve(size_t capacity) override;
+    void reserve(size_t capacity, std::vector<Extent> *extents) override;
 
     struct InternalExtent {
         Extent extent;
@@ -93,8 +95,6 @@ public:
         size_t copyout(char *buf, size_t size);
         size_t consume(size_t size);
     };
-
-    static BufferImpl* get(Buffer *buf);
 private:
     bool list_empty() const;
     void read(char *buf, size_t size, size_t *nread, bool consume);

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -31,10 +31,6 @@
 
 namespace wte {
 
-BufferImpl* BufferImpl::get(Buffer *buf) {
-    return buf->pImpl_;
-}
-
 size_t BufferImpl::InternalExtent::append(const char *buf, size_t size) {
     char *data = extent.data;
     size_t space = write_offset - extent.size;
@@ -154,7 +150,13 @@ void BufferImpl::append(const char *buf, size_t size) {
     size_ += size;
 }
 
-void BufferImpl::append(BufferImpl *o) {
+void BufferImpl::append(std::string const& buf) {
+    append(buf.c_str(), buf.size());
+}
+
+void BufferImpl::append(Buffer *orig) {
+    BufferImpl *o = static_cast<BufferImpl*>(orig);
+
     if (o->list_empty()) {
         return;
     }
@@ -187,7 +189,13 @@ void BufferImpl::prepend(const char *buf, size_t size) {
     size_ += size;
 }
 
-void BufferImpl::prepend(BufferImpl *o) {
+void BufferImpl::prepend(std::string const& buf) {
+    prepend(buf.c_str(), buf.size());
+}
+
+void BufferImpl::prepend(Buffer *orig) {
+    BufferImpl *o = static_cast<BufferImpl*>(orig);
+
     if (o->list_empty()) {
         return;
     }
@@ -282,70 +290,18 @@ void BufferImpl::peek(size_t size, std::vector<Extent> *extents) const {
     }
 }
 
-void Buffer::append(const char *buf, size_t size) {
-    return pImpl_->append(buf, size);
+Buffer::~Buffer() { }
+
+Buffer* Buffer::mkBuffer() {
+    return new BufferImpl();
 }
 
-void Buffer::append(std::string const& buffer) {
-    return pImpl_->append(buffer.c_str(), buffer.size());
+void Buffer::release(Buffer *buf) {
+    delete buf;
 }
 
-void Buffer::append(Buffer *buf) {
-    return pImpl_->append(buf->pImpl_);
+void Buffer::Deleter::operator()(Buffer *buf) {
+    delete buf;
 }
-
-void Buffer::prepend(const char *buf, size_t size) {
-    return pImpl_->prepend(buf, size);
-}
-
-void Buffer::prepend(std::string const& buffer) {
-    return pImpl_->prepend(buffer.c_str(), buffer.size());
-}
-
-void Buffer::prepend(Buffer *buf) {
-    return pImpl_->prepend(buf->pImpl_);
-}
-
-bool Buffer::empty() const {
-    return pImpl_->empty();
-}
-
-size_t Buffer::size() const {
-    return pImpl_->size();
-}
-
-void Buffer::reserve(size_t size) {
-    return pImpl_->reserve(size);
-}
-
-void Buffer::reserve(size_t size, std::vector<Extent> *extents) {
-    return pImpl_->reserve(size, extents);
-}
-
-void Buffer::drain(size_t size) {
-    pImpl_->drain(size);
-}
-
-void Buffer::read(char *buf, size_t size, size_t *nread) {
-    return pImpl_->read(buf, size, nread);
-}
-
-void Buffer::peek(char *buf, size_t size, size_t *nread) const {
-    return pImpl_->peek(buf, size, nread);
-}
-
-void Buffer::peek(size_t size, std::vector<Extent> *extents) const {
-    return pImpl_->peek(size, extents);
-}
-
-Buffer::~Buffer() {
-    delete pImpl_;
-}
-
-Buffer::Buffer(Buffer &&o) : pImpl_(o.pImpl_) {
-    o.pImpl_ = nullptr;
-}
-
-Buffer::Buffer() : pImpl_(new BufferImpl()) { }
 
 } // wte namespace

--- a/src/libevent_connection_listener.cc
+++ b/src/libevent_connection_listener.cc
@@ -168,11 +168,13 @@ void LibeventConnectionListener::stopAccepting() {
     base_->registerHandler(&handler_, What::NONE);
 }
 
-ConnectionListener* mkConnectionListener(
+std::shared_ptr<ConnectionListener> mkConnectionListener(
         std::shared_ptr<EventBase> base,
         std::function<void(int)> const& acceptCallback,
         std::function<void(std::exception const&)> errorCallback) {
-    return new LibeventConnectionListener(base, acceptCallback, errorCallback);
+    return std::shared_ptr<ConnectionListener>(
+        new LibeventConnectionListener(base, acceptCallback, errorCallback),
+        std::default_delete<ConnectionListener>());
 }
 
 } // wte namespace

--- a/src/libevent_connection_listener.cc
+++ b/src/libevent_connection_listener.cc
@@ -42,7 +42,8 @@
 
 namespace wte {
 
-LibeventConnectionListener::LibeventConnectionListener(EventBase *base,
+LibeventConnectionListener::LibeventConnectionListener(
+        std::shared_ptr<EventBase> base,
         std::function<void(int)> const& acceptCallback,
         std::function<void(std::exception const&)> errorCallback)
     : base_(base), port_(0), acceptCallback_(acceptCallback),
@@ -167,7 +168,8 @@ void LibeventConnectionListener::stopAccepting() {
     base_->registerHandler(&handler_, What::NONE);
 }
 
-ConnectionListener* mkConnectionListener(EventBase *base,
+ConnectionListener* mkConnectionListener(
+        std::shared_ptr<EventBase> base,
         std::function<void(int)> const& acceptCallback,
         std::function<void(std::exception const&)> errorCallback) {
     return new LibeventConnectionListener(base, acceptCallback, errorCallback);

--- a/src/libevent_connection_listener.h
+++ b/src/libevent_connection_listener.h
@@ -32,7 +32,7 @@ namespace wte {
 // here. Consider making generic, like Stream.
 class LibeventConnectionListener final : public ConnectionListener {
 public:
-    LibeventConnectionListener(EventBase *loop,
+    LibeventConnectionListener(std::shared_ptr<EventBase> loop,
         std::function<void(int)> const& acceptCallback,
         std::function<void(std::exception const&)> errorCallback);
     ~LibeventConnectionListener();
@@ -53,7 +53,7 @@ private:
         LibeventConnectionListener *listener_;
     };
 
-    EventBase *base_;
+    std::shared_ptr<EventBase> base_;
     uint16_t port_;
     std::function<void(int)> acceptCallback_;
     std::function<void(std::exception const&)> errorCallback_;

--- a/src/libevent_event_base.cc
+++ b/src/libevent_event_base.cc
@@ -543,8 +543,11 @@ void LibeventEventBase::registerHandlerInternal(EventHandler *handler,
     event_add(&impl->event_, /*timeout=*/ nullptr);
 }
 
-EventBase* mkEventBase() {
-    return new LibeventEventBase();
+std::shared_ptr<EventBase> mkEventBase() {
+    // Using an explicit deleter here ensures that the delete is performed
+    // by this library, avoiding cross-DLL delete issues on Windows.
+    return std::shared_ptr<EventBase>(
+        new LibeventEventBase(), std::default_delete<EventBase>());
 }
 
 } // wte namespace

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -66,11 +66,11 @@ inline bool isReadRetryable(int e) {
 class StreamImpl final : public Stream {
 public:
     // TODO: temporary fd-based constructor for testing
-    StreamImpl(EventBase *base, int fd) : handler_(this, fd),
+    StreamImpl(std::shared_ptr<EventBase> base, int fd) : handler_(this, fd),
         base_(base), requests_({nullptr, nullptr}), readCallback_(nullptr),
         connectCallback_(nullptr) { }
 
-    explicit StreamImpl(EventBase *base) : handler_(this, -1),
+    explicit StreamImpl(std::shared_ptr<EventBase> base) : handler_(this, -1),
         base_(base), requests_({nullptr, nullptr}), readCallback_(nullptr),
         connectCallback_(nullptr) { }
 
@@ -109,7 +109,7 @@ private:
     };
 
     SockHandler handler_;
-    EventBase *base_;
+    std::shared_ptr<EventBase> base_;
     struct Requests {
         WriteRequest *head;
         WriteRequest *tail;
@@ -420,12 +420,14 @@ void Stream::Deleter::operator()(Stream *stream) {
     delete stream;
 }
 
-std::unique_ptr<Stream, Stream::Deleter> wrapFd(EventBase *base, int fd) {
+std::unique_ptr<Stream, Stream::Deleter> wrapFd(std::shared_ptr<EventBase> base,
+        int fd) {
     return std::unique_ptr<Stream, Stream::Deleter>(
          new StreamImpl(base, fd), Stream::Deleter());
 }
 
-std::unique_ptr<Stream, Stream::Deleter> Stream::create(EventBase *base) {
+std::unique_ptr<Stream, Stream::Deleter> Stream::create(
+        std::shared_ptr<EventBase> base) {
     return std::unique_ptr<Stream, Stream::Deleter>(
          new StreamImpl(base), Stream::Deleter());
 }

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -38,6 +38,7 @@
 
 #include <event2/util.h>
 
+#include "buffer-internal.h"
 #include "wte/buffer.h"
 #include "wte/event_base.h"
 #include "wte/event_handler.h"
@@ -102,7 +103,7 @@ private:
         WriteRequest(const char *buffer, size_t size, WriteCallback *cb);
         WriteRequest(Buffer *buf, WriteCallback *cb);
         ~WriteRequest();
-        Buffer buffer_;
+        BufferImpl buffer_;
         WriteCallback *callback_;
         WriteRequest *next_;
     };
@@ -138,7 +139,7 @@ private:
     } requests_;
     ReadCallback *readCallback_;
     ConnectCallback *connectCallback_;
-    Buffer readBuffer_;
+    BufferImpl readBuffer_;
 };
 
 void StreamImpl::SockHandler::ready(What event) NOEXCEPT {

--- a/src/wte/blocking_stream.h
+++ b/src/wte/blocking_stream.h
@@ -32,17 +32,23 @@ namespace wte {
 class EventBase;
 
 /** Read/write stream with blocking operations. */
-class WTE_SYM BlockingStream {
+class BlockingStream {
 public:
+    BlockingStream() { }
+    virtual ~BlockingStream() { }
+
+    struct WTE_SYM Deleter {
+        void operator()(BlockingStream *);
+    };
+
     /**
      * Construct a blocking stream wrapper around an existing descriptor.
      *
      * @param fd the file descriptor
      * @param auto_close whether to close the descriptor on destruction
      */
-    explicit BlockingStream(int fd, bool auto_close);
-
-    ~BlockingStream();
+    static std::unique_ptr<BlockingStream, Deleter> create(int fd,
+        bool auto_close);
 
     /**
      * Writes the buffer into the stream, blocking if necessary.
@@ -51,7 +57,7 @@ public:
      * @param size the buffer length
      * @throws on error
      */
-    void write(const char *buf, size_t size);
+    virtual void write(const char *buf, size_t size) = 0;
 
     /**
      * Read up to the requested size, blocking if necessary.
@@ -63,11 +69,7 @@ public:
      * @return the number of bytes read
      * @throws on error
      */
-    int64_t read(char *buf, size_t size);
-private:
-    EventBase *base_;
-    std::unique_ptr<Stream, Stream::Deleter> stream_;
-    bool close_;
+    virtual int64_t read(char *buf, size_t size) = 0;
 };
 
 } // wte namespace

--- a/src/wte/connection_listener.h
+++ b/src/wte/connection_listener.h
@@ -99,7 +99,8 @@ public:
  * @param errorCallback the callback to be invoked on errors
  * @throws on error
  */
-WTE_SYM ConnectionListener* mkConnectionListener(EventBase *base,
+WTE_SYM ConnectionListener* mkConnectionListener(
+    std::shared_ptr<EventBase> base,
     std::function<void(int fd)> const& acceptCallback,
     std::function<void(std::exception const&)> errorCallback);
 

--- a/src/wte/connection_listener.h
+++ b/src/wte/connection_listener.h
@@ -23,6 +23,7 @@
 
 #include <cinttypes>
 #include <functional>
+#include <memory>
 
 #include "wte/event_base.h"
 #include "wte/porting.h"
@@ -43,7 +44,7 @@ namespace wte {
  * `startAccepting` are invoked, and the event base is driven by its
  * `loop` method.
  */
-class WTE_SYM ConnectionListener {
+class ConnectionListener {
 public:
     virtual ~ConnectionListener() { }
 
@@ -99,7 +100,7 @@ public:
  * @param errorCallback the callback to be invoked on errors
  * @throws on error
  */
-WTE_SYM ConnectionListener* mkConnectionListener(
+WTE_SYM std::shared_ptr<ConnectionListener> mkConnectionListener(
     std::shared_ptr<EventBase> base,
     std::function<void(int fd)> const& acceptCallback,
     std::function<void(std::exception const&)> errorCallback);

--- a/src/wte/event_base.h
+++ b/src/wte/event_base.h
@@ -22,6 +22,7 @@
 #define WTE_EVENT_BASE_H_
 
 #include <functional>
+#include <memory>
 
 #include "wte/porting.h"
 #include "wte/what.h"
@@ -31,7 +32,7 @@ namespace wte {
 class EventHandler;
 class Timeout;
 
-class WTE_SYM EventBase {
+class EventBase {
 public:
     enum class LoopMode {
         /** Process active events and return. */
@@ -131,7 +132,7 @@ public:
 };
 
 /** @return a new event base. */
-WTE_SYM EventBase *mkEventBase();
+WTE_SYM std::shared_ptr<EventBase> mkEventBase();
 
 } // wte namespace
 

--- a/src/wte/stream.h
+++ b/src/wte/stream.h
@@ -52,7 +52,8 @@ public:
      * @param base the event base for stream IO
      * @return an unconnected stream
      */
-    WTE_SYM static std::unique_ptr<Stream, Deleter> create(EventBase *base);
+    WTE_SYM static std::unique_ptr<Stream, Deleter> create(
+        std::shared_ptr<EventBase> base);
 
     virtual ~Stream() { }
 
@@ -170,7 +171,8 @@ public:
 
 // TODO: temporary interface for testing. Must already be connected & set
 // to non-blocking mode.
-WTE_SYM std::unique_ptr<Stream, Stream::Deleter> wrapFd(EventBase *base, int fd);
+WTE_SYM std::unique_ptr<Stream, Stream::Deleter> wrapFd(
+    std::shared_ptr<EventBase> base, int fd);
 
 } // wte namespace
 

--- a/src/wte/stream.h
+++ b/src/wte/stream.h
@@ -35,7 +35,7 @@ namespace wte {
 /**
  * Interface for an asynchronous data stream.
  */
-class WTE_SYM Stream {
+class Stream {
 public:
     class WTE_SYM Deleter {
     public:
@@ -52,7 +52,7 @@ public:
      * @param base the event base for stream IO
      * @return an unconnected stream
      */
-    static std::unique_ptr<Stream, Deleter> create(EventBase *base);
+    WTE_SYM static std::unique_ptr<Stream, Deleter> create(EventBase *base);
 
     virtual ~Stream() { }
 

--- a/test/blocking_stream_test.cc
+++ b/test/blocking_stream_test.cc
@@ -75,28 +75,28 @@ public:
 };
 
 TEST_F(BlockingStreamTest, ReadWrite) {
-    BlockingStream writer(fds[0], /*close=*/ false);
-    BlockingStream reader(fds[1], /*close=*/ false);
+    auto writer = BlockingStream::create(fds[0], /*close=*/ false);
+    auto reader = BlockingStream::create(fds[1], /*close=*/ false);
 
     char buf[64];
     memset(buf, 'A', sizeof(buf));
 
-    writer.write(buf, sizeof(buf));
-    ASSERT_TRUE(received(reader, buf, sizeof(buf)));
+    writer->write(buf, sizeof(buf));
+    ASSERT_TRUE(received(*reader, buf, sizeof(buf)));
 }
 
 TEST_F(BlockingStreamTest, ShortRead) {
-    BlockingStream writer(fds[0], /*close=*/ false);
-    BlockingStream reader(fds[1], /*close=*/ false);
+    auto writer = BlockingStream::create(fds[0], /*close=*/ false);
+    auto reader = BlockingStream::create(fds[1], /*close=*/ false);
 
     char wbuf[64];
     memset(wbuf, 'A', sizeof(wbuf));
-    writer.write(wbuf, sizeof(wbuf));
+    writer->write(wbuf, sizeof(wbuf));
 
     closepipe<0>();
 
     char rbuf[128];
-    int nread = reader.read(rbuf, sizeof(rbuf));
+    int nread = reader->read(rbuf, sizeof(rbuf));
     ASSERT_EQ(sizeof(wbuf), nread);
 }
 

--- a/test/connection_listener_test.cc
+++ b/test/connection_listener_test.cc
@@ -38,9 +38,8 @@ public:
 
 protected:
     template<typename... Params>
-    std::unique_ptr<ConnectionListener> mkListener(Params... params) {
-        return std::unique_ptr<ConnectionListener>(
-            mkConnectionListener(std::forward<Params>(params)...));
+    std::shared_ptr<ConnectionListener> mkListener(Params... params) {
+        return mkConnectionListener(std::forward<Params>(params)...);
     }
 
     std::function<void(int)> mkAccept() {

--- a/test/event_base_test.h
+++ b/test/event_base_test.h
@@ -52,7 +52,6 @@ public:
     ~EventBaseTest() {
         closepipe<0>();
         closepipe<1>();
-        delete base;
     }
 
     // Trading additional code emitted for avoiding parameter type screw-ups :P
@@ -66,7 +65,7 @@ public:
     }
 protected:
     evutil_socket_t fds[2]; // Directly depending on libevent utils
-    EventBase *base;
+    std::shared_ptr<EventBase> base;
 };
 
 } // namespace wte

--- a/test/stream_test.cc
+++ b/test/stream_test.cc
@@ -34,8 +34,8 @@ class EchoServer {
 public:
     struct Connection;
 
-    EchoServer(EventBase *base, int accept_count = -1) : base(base),
-            accept(accept_count) {
+    EchoServer(std::shared_ptr<EventBase> base, int accept_count = -1)
+            : base(base), accept(accept_count) {
         listener = mkConnectionListener(base, [this](int fd) -> void {
                 Connection *conn = new Connection(this, wrapFd(this->base, fd));
                 connections.insert(conn);
@@ -119,7 +119,7 @@ public:
         WriteCallback write_cb;
     };
 
-    EventBase *base;
+    std::shared_ptr<EventBase> base;
     int accept;
     ConnectionListener *listener;
     std::set<Connection*> connections;

--- a/test/stream_test.cc
+++ b/test/stream_test.cc
@@ -55,7 +55,7 @@ public:
     }
 
     ~EchoServer() {
-        delete listener;
+        listener.reset();
 
         for (auto* conn : connections) {
             conn->server = nullptr;
@@ -121,7 +121,7 @@ public:
 
     std::shared_ptr<EventBase> base;
     int accept;
-    ConnectionListener *listener;
+    std::shared_ptr<ConnectionListener> listener;
     std::set<Connection*> connections;
 };
 


### PR DESCRIPTION
Exporting classes across DLL boundaries is fraught, especially when memory management comes into play. This patch series converts most of the public interfaces to pure virtual (most already were), and amends most of the factory methods to `std::shared_ptr` or `std::unique_ptr` with DLL-side deleters, ensuring that application-side variation in runtime library don't cause corruption.
